### PR TITLE
Fix TypeError raised by manual TOC placement

### DIFF
--- a/wikimarkup/parser.py
+++ b/wikimarkup/parser.py
@@ -2237,7 +2237,7 @@ class Parser(BaseParser):
             i += 4
         full = ''.join(str(x) for x in full)
         if forceTocPosition != -1:
-            return full.replace("<!--MWTOC-->", ''.join(toc), 1)
+            return full.replace("<!--MWTOC-->", ''.join(str(x) for x in toc), 1)
         else:
             return full
 

--- a/wikimarkup/tests.py
+++ b/wikimarkup/tests.py
@@ -212,3 +212,18 @@ class WikimarkupTestCase(unittest.TestCase):
         assumed = '<div id="toc"><h2>TOC</h2><ul><li class="toclevel-1"><a href="#w_my-heading"><span class="tocnumber">1</span> <span class="toctext">My Heading</span></a><ul><li class="toclevel-2"><a href="#w_subheading"><span class="tocnumber">1.1</span> <span class="toctext">Subheading</span></a></li><li class="toclevel-2"><a href="#w_show-me-a-toc"><span class="tocnumber">1.2</span> <span class="toctext">show me a toc</span></a><ul><li class="toclevel-3"><a href="#w_pretty-please"><span class="tocnumber">1.2.1</span> <span class="toctext">pretty please</span></a></li></ul></li></ul></li></ul></div><h1 id="w_my-heading">My Heading</h1>\n<ul><li> here\n</li><li> is\n</li><li> a\n</li><li> <a href="http://mydomain.com">list</a>\n</li></ul>\n<h2 id="w_subheading">Subheading</h2>\n<h2 id="w_show-me-a-toc">show me a toc</h2>\n<h3 id="w_pretty-please">pretty please</h3>'
         self.assertEqual(parse(text, toc_string='TOC'), assumed)
 
+    def test_toc_placement(self):
+        """
+        TOC is placed where the <!--MWTOC--> comment is within the text.
+        """
+        text = """=First Heading=\n<!--MWTOC-->\nstuff"""
+        assumed = '<h1 id="w_first-heading">First Heading</h1>\n<div id="toc"><h2>Table of Contents</h2><ul><li class="toclevel-1"><a href="#w_first-heading"><span class="tocnumber">1</span> <span class="toctext">First Heading</span></a></li></ul></div>\n<p>stuff\n</p>'
+        self.assertEqual(parse(text), assumed)
+
+    def test_forced_toc(self):
+        """
+        Text containing __FORCETOC__ will have a toc regardless of length.
+        """
+        text = """=First Heading=\n__FORCETOC__\nstuff"""
+        assumed = '<div id="toc"><h2>Table of Contents</h2><ul><li class="toclevel-1"><a href="#w_first-heading"><span class="tocnumber">1</span> <span class="toctext">First Heading</span></a></li></ul></div><h1 id="w_first-heading">First Heading</h1>\n<p>stuff\n</p>'
+        self.assertEqual(parse(text), assumed)


### PR DESCRIPTION
Prior to commit ce7d10dbd421533bb9b0c41dd9c9d09298a51a41 text could contain `<!--MWTOC-->` to indicate where the TOC should be placed. It has not worked since then because of a `TypeError` being raised.

```
======================================================================
ERROR: test_toc_placement (wikimarkup.tests.WikimarkupTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/ben/n/ll/py-wikimarkup/wikimarkup/tests.py", line 225, in test_toc_placement
    self.assertEqual(parse(text), assumed)
  File "/Users/ben/n/ll/py-wikimarkup/wikimarkup/parser.py", line 2252, in parse
    nofollow=nofollow, toc_string=toc_string)
  File "/Users/ben/n/ll/py-wikimarkup/wikimarkup/parser.py", line 1654, in parse
    text = self.formatHeadings(text, True, toc_string)
  File "/Users/ben/n/ll/py-wikimarkup/wikimarkup/parser.py", line 2240, in formatHeadings
    return full.replace("<!--MWTOC-->", ''.join(toc), 1)
TypeError: sequence item 3: expected str instance, int found
```

This PR fixes that and adds some tests.